### PR TITLE
EXL-287 - Added plugin config handling

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## unreleased
 
+- EXL-287 - Added plugin config handling
 - EXL-284 - Clean up unnecessary menu items
 - EXL-285 - Added htaccess based redirect to https 
 - EXL-274 - Added import tab to the config page

--- a/plugin/config/config.php
+++ b/plugin/config/config.php
@@ -1,0 +1,7 @@
+<?php
+
+/* Array keys must use dot notation, e.g. 'config_override.core.palette' => 'auror'. */
+
+return [
+    'version' => '0.0.1',
+];

--- a/plugin/inc/config.class.php
+++ b/plugin/inc/config.class.php
@@ -4,6 +4,8 @@ use Glpi\Application\View\TemplateRenderer;
 
 class PluginIserviceConfig extends CommonDBTM
 {
+    private const LOCAL_CONFIG_FILE   = PLUGIN_ISERVICE_DIR . '/config/local.php';
+    private const DEFAULT_CONFIG_FILE = PLUGIN_ISERVICE_DIR . '/config/config.php';
 
     public static $rightname = 'config';
 
@@ -22,13 +24,13 @@ class PluginIserviceConfig extends CommonDBTM
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0): array
     {
         switch ($item->getType()) {
-            case __CLASS__:
-                return [
-                    1 => __('General setup'),
-                    2 => __('Import'),
-                ];
-            default:
-                break;
+        case __CLASS__:
+            return [
+                1 => __('General setup'),
+                2 => __('Import'),
+            ];
+        default:
+            break;
         }
 
         return [];
@@ -59,17 +61,132 @@ class PluginIserviceConfig extends CommonDBTM
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0): bool
     {
         switch ($tabnum) {
-            case 1:
-                $item->showFormGeneral($item);
-                break;
-            case 2:
-                $item->showFormImport($item);
-                break;
-            default:
-                break;
+        case 1:
+            $item->showFormGeneral($item);
+            break;
+        case 2:
+            $item->showFormImport($item);
+            break;
+        default:
+            break;
         }
 
         return true;
+    }
+
+    public static function getConfigValue(string $name)
+    {
+        $value = self::getValueFromSession($name);
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        $value = self::getValueFromDatabase($name);
+
+        if ($value !== null && $value != 'N/A') {
+            self::setValueToSession($name, $value);
+            return $value;
+        }
+
+        $value = self::getValueFromConfigFile($name, self::LOCAL_CONFIG_FILE);
+
+        if ($value !== null) {
+            self::setValueToSession($name, $value);
+            return $value;
+        }
+
+        $value = self::getValueFromConfigFile($name, self::DEFAULT_CONFIG_FILE);
+
+        if ($value !== null) {
+            self::setValueToSession($name, $value);
+            return $value;
+        }
+
+        return null;
+    }
+
+    public static function getValueFromSession(string $name)
+    {
+        return $_SESSION['plugin']['iservice']['config'][$name] ?? null;
+    }
+
+    public static function setValueToSession(string $name, $value)
+    {
+        $_SESSION['plugin']['iservice']['config'][$name] = $value;
+    }
+
+    public static function getValueFromDatabase(string $name)
+    {
+        $config = new self();
+        $config->getFromDBByCrit(
+            [
+                'name' => $name,
+            ]
+        );
+
+        if ($config->getField('value') !== null) {
+            return $config->getField('value');
+        }
+    }
+
+    public static function getValueFromConfigFile(string $name, string $file)
+    {
+        $localConfig = include $file;
+
+        return $localConfig[$name] ?? null;
+    }
+
+    public static function handleConfigValues(): void
+    {
+        if (isset($_SESSION['plugin']['iservice']['config']) && count($_SESSION['plugin']['iservice']['config']) > 0) {
+            return;
+        }
+
+        $valuesFromDB = (new self)->find();
+        $valuesFromDB = array_combine(array_column($valuesFromDB, 'name'), array_column($valuesFromDB, 'value')) ?? [];
+
+        $valuesFromLocalConfig = include self::LOCAL_CONFIG_FILE ?? [];
+        $valuesFromMainConfig  = include self::DEFAULT_CONFIG_FILE ?? [];
+
+        $configArray = array_merge($valuesFromMainConfig, $valuesFromLocalConfig, $valuesFromDB);
+
+        $_SESSION['plugin']['iservice']['config'] = $configArray;
+        self::overrideConfig($configArray);
+    }
+
+    public static function overrideConfig($configArray): void
+    {
+        if (empty($configArray)) {
+            return;
+        }
+
+        $configValuesToOverride = array_filter(
+            array_keys($configArray), function ($key) {
+                return str_starts_with($key, 'config_override');
+            }
+        );
+
+        if (!empty($configValuesToOverride)) {
+            foreach ($configValuesToOverride as $configValueToOverride) {
+                list($prefix, $context, $configName) = explode('.', $configValueToOverride, 3);
+
+                $config = new Config();
+                $config->getFromDBByCrit(
+                    [
+                        'context' => $context,
+                        'name' => $configName,
+                    ]
+                );
+                $config->update(
+                    [
+                        $config->getIndexName() => $config->getID(),
+                        'context' => $context,
+                        'value' => $configArray[$configValueToOverride],
+                    ]
+                );
+            }
+        }
     }
 
 }

--- a/plugin/setup.php
+++ b/plugin/setup.php
@@ -48,6 +48,8 @@ function plugin_init_iservice(): void
         $PLUGIN_HOOKS['add_javascript']['iservice'] = "js/import.js";
 
         $PLUGIN_HOOKS['redefine_menus']['iservice'] = 'plugin_iservice_redefine_menus';
+
+        PluginIserviceConfig::handleConfigValues();
     }
 }
 


### PR DESCRIPTION
- Config values are saved to session after login in the following way: values from database have the highest priority, followed by local.php, then config.php config files.
- GLPI config overrides are also done in the above step
- Any changes in the existing config values take effect only after session config clear
- If new values are added to the config, it will be cached after first access with getConfigValue() method