### PR TITLE
EXL-378 global read counter tickets adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ See the setup instructions for the DEV, TEST and PROD environments [here](setup/
 # Useful tips
 
 - The glpi system uses [Tabler Icons](https://tabler-icons.io) and [Font Awesome](https://fontawesome.com) for icons. You can find the icon names in the websites.
+
+# GLPI hacks
+
+- Update: glpi/src/RichText/UserMention.php, line, handleUserMentions() method, line 80 to: `$previous_value = $item->fields[$content_field] ?? null`;

--- a/plugin/inc/utils/toolbox.class.php
+++ b/plugin/inc/utils/toolbox.class.php
@@ -363,6 +363,15 @@ class ToolBox
         }
     }
 
+    public static function getUserIdByName($name)
+    {
+        $user = new \User();
+        $user->getFromDBbyName($name);
+        $id = $user->getID();
+
+         return $id > -1 ? $id : 0;
+    }
+
     public static function getUsersByProfiles(array $profileNames): array
     {
         $users = [

--- a/plugin/inc/views/operations.class.php
+++ b/plugin/inc/views/operations.class.php
@@ -71,7 +71,7 @@ class Operations extends View
 
     public static function getTicketConsumablesDisplay($row_data): string
     {
-        $export_type = empty($row_data['plugin_fields_ticketexporttypedropdowns_id']) ? '' : ucfirst("$row_data[plugin_fields_ticketexporttypedropdowns_id]<br>");
+        $export_type = empty($row_data['plugin_fields_ticketexporttypedropdowns_id']) ? '' : PluginIserviceTicket::getExportType($row_data['plugin_fields_ticketexporttypedropdowns_id']) . '<br>';
         if ($row_data['ticket_exported']) {
             return "<b>$export_type</b>$row_data[ticket_consumables]";
         } else {

--- a/plugin/templates/pages/support/ticket.html.twig
+++ b/plugin/templates/pages/support/ticket.html.twig
@@ -83,7 +83,18 @@
 
                             {% set canUpdateInitalValue = canupdate %}
                             {% set canupdate = false %}
-                            {{ include('components/itilobject/fields/status.html.twig') }}
+                            <div id="statusElementContainer">
+                                {{ include('components/itilobject/fields/status.html.twig') }}
+                                {% if item.fields['status'] == constant('Ticket::CLOSED') %}
+                                    <script>
+                                        const statusElementContainer = $('#statusElementContainer');
+                                        if (statusElementContainer.find('.closed').length > 0 && statusElementContainer.find('.btn').length > 0) {
+                                            statusElementContainer.find('.btn').remove();
+                                        }
+                                    </script>
+                                {% endif %}
+                            </div>
+
                             {% set canupdate = canUpdateInitalValue %}
 
                             {{ fields.checkboxField(
@@ -124,6 +135,13 @@
                                 <div class="add-consumable-div">
                                     {{ include('@iservice/pages/support/components/consumables_table.html.twig') }}
                                 </div>
+                                {% if item.customfields.fields['plugin_fields_ticketexporttypedropdowns_id'] == 0 %}
+                                    <script>
+                                        $(document).ready(function(){
+                                            $(".add-consumable-div").hide();
+                                        });
+                                    </script>
+                                {% endif %}
                             {% endif %}
 
                             {% if item.hasConsumables() %}


### PR DESCRIPTION
EXL-378 - Fixed export type display on 'Lista lucrari' 

EXL-360 - Change export type field to be ---- by default

EXL-378 - Modified read counter ticket user assignment, so that in case of 'client', 'superclient', 'admin', 'super-admin', the assigned user will be the logged in one, in other case the user with name 'Cititor'